### PR TITLE
Improved setup of CPUTAPID for STM32 configuration.

### DIFF
--- a/tcl/target/stm32f1x.cfg
+++ b/tcl/target/stm32f1x.cfg
@@ -39,11 +39,17 @@ if { [info exists CPUTAPID] } {
       set _CPUTAPID 0x3ba00477
    } {
       # this is the SW-DP tap id not the jtag tap id
-      set _CPUTAPID 0x1ba01477
+      set _CPUTAPID {0x1ba01477 0x2ba01477}
    }
 }
 
-swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+# Expand CPUTAPID parameters
+set _EXPECTED_IDS {}
+foreach id $_CPUTAPID {
+   lappend _EXPECTED_IDS -expected-id $id
+}
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf {*}$_EXPECTED_IDS
 dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
 
 if {[using_jtag]} {


### PR DESCRIPTION
### Contribution
This PR updates this STM32 configuration file to allow multiple declarations of possible IDs (which should be already available according to
```
-expected-id NUMBER
A non-zero number represents a 32-bit IDCODE which you expect to find when the scan chain is examined. These codes are not required by all JTAG devices. Repeat the option as many times as required if more than one ID code could appear (for example, multiple versions). Specify number as zero to suppress warnings about IDCODE values that were found but not included in the list.
```
**This PR should not change any previous operation, it reads: backward compatibility**

### Fixed
Also, using the new feature, it contains the new possible version of STM32's IDs `0x2ba01477`.

I hope you like it.