### PR TITLE
Update stm32f2x.cfg

### DIFF
--- a/tcl/target/stm32f2x.cfg
+++ b/tcl/target/stm32f2x.cfg
@@ -71,6 +71,22 @@ if {![using_hla]} {
    # perform a soft reset
    cortex_m reset_config sysresetreq
 }
+# added by mariwan  - Start
+$_TARGETNAME configure -event reset-init {
+	# CPU comes out of reset with MSI_ON | MSI_RDY | MSI Range 6 (4 MHz).
+	# Use MSI 24 MHz clock, compliant even with VOS == 2.
+	# 3 WS compliant with VOS == 2 and 24 MHz.
+	mww 0x40022000 0x00000103   ;# FLASH_ACR = PRFTBE | 3(Latency)
+	mww 0x40021000 0x00000099   ;# RCC_CR = MSI_ON | MSIRGSEL | MSI Range 9
+	# Boost JTAG frequency
+	adapter speed 4000
+}
+
+$_TARGETNAME configure -event reset-start {
+	# Reset clock is MSI (4 MHz)
+	adapter speed 500
+}
+# added by mariwan  - END
 
 $_TARGETNAME configure -event examine-end {
 	# DBGMCU_CR |= DBG_STANDBY | DBG_STOP | DBG_SLEEP


### PR DESCRIPTION
Without this part that I added, debugging will never start and the OpenOCD cannot reset-halt the Nucleo(I have NucleoF207ZG).
Please notice that even with this, if you have double USB-HUB .. OpenOCD will fail. 
I don't know what to do to avoid that. Please advice how we can fix that issue. It seems that there will be more delay (in answring OpenOCD) from the Device that make it impossible for OpeonOCD to reset and halt the device.
Please consider this information even for other Nucleo boards (I tested double-USB hub even with Nucleo-L476RG- It will fail if I connect my board to a USB-HUB which is connected to a Laptop-expantion (has also a usb hub sure) .. I couldn't debug. 
The part I borrowed from the STM32LX.cfg file .. might need adjustion . 
I hope this help folk out there . .I spent days and days to find a solution .. 
Thanks
Mariwan