### PR TITLE
STM8L051 and STM8L101 STM8L Low density cfg

### DIFF
--- a/tcl/target/stm8l051.cfg
+++ b/tcl/target/stm8l051.cfg
@@ -1,0 +1,14 @@
+#config script for STM8L051
+
+set FLASHEND 0x9FFF
+set BLOCKSIZE 0x40
+set EEPROMSTART 0x1000
+set EEPROMEND 0x10ff
+
+proc stm8_reset_rop {} {
+   mwb 0x4800 0xaa
+   mwb 0x4800 0xaa
+   reset halt
+}
+
+source [find target/stm8l.cfg]

--- a/tcl/target/stm8l101.cfg
+++ b/tcl/target/stm8l101.cfg
@@ -1,0 +1,11 @@
+#config script for STM8L101
+
+set FLASHEND 0x9FFF
+set BLOCKSIZE 0x40
+
+proc stm8_reset_rop {} {
+   mwb 0x4800 0x00
+   reset halt
+}
+
+source [find target/stm8l.cfg]


### PR DESCRIPTION
These cfg files for STM8L Low density were derived from stm8l152.cfg, and tested with the last release.

A write-up on using openocd with STM8 devices is here: https://gist.github.com/TG9541/79aa3bb1a56a8220eac8f57ab21302e1